### PR TITLE
NEST-587: Bundling ESlint related dependencies in renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,4 +4,13 @@
     'prBodyNotes': [
         '@Lombiq/dotnest-sites-renovate-notification-recipients',
     ],
+    packageRules: [
+        // ESLint-related dependencies should be updated together.
+        {
+            groupName: 'ESLint Updates',
+            matchPackageNames: [
+                'eslint*',
+            ],
+        },
+    ],
 }


### PR DESCRIPTION
[NEST-587](https://lombiq.atlassian.net/browse/NEST-587)

[NEST-587]: https://lombiq.atlassian.net/browse/NEST-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ